### PR TITLE
Solaris 11 support added to COE

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # COE
-Common Oracle Environment for Linux
+Common Oracle Environment for Linux and Solaris
 
 ### Installation instructions for the Oracle Cloud Infrastructure
 ```
@@ -16,7 +16,7 @@ echo ". ~/COE/profile.sh" >> $HOME/.bash_profile
 . ~/.bash_profile
 ```
 
-### (optional) Installing git and rlwrap
+### (optional) Installing git and rlwrap on Linux
 ```
 #### IF USING RH6/OL6 (OL6 is the old VM provided as DBaaS in Oracle Cloud)
 # install EPEL repo for rlwrap 
@@ -44,6 +44,17 @@ sudo yum install -y rlwrap git
 ```
 Depending on your VM version, you might encounter problems installing rlwrap. Please let me know if you find a one-command-fits all.
 
+### (optional) Installing git and rlwrap on Oracle Solaris 11
+```
+#### install pkgutil
+# pkgadd -d http://get.opencsw.org/now CSWpkgutil
+#### update repository
+# /opt/csw/bin/pkgutil -U
+####  install rlwrap + dependencies
+# /opt/csw/bin/pkgutil -y -i rlwrap
+
+### utilities are installed to /opt/csw/bin. This path is added to PATH in variables.conf
+```
 
 ## Some examples of the environment:
 ```

--- a/functions.conf
+++ b/functions.conf
@@ -121,6 +121,7 @@ function F_pmon_running () {
 
 function dbsingle {
 
+
 	my_sid=$1
 	if [ -z "$my_sid" ] ; then
 		singlestat
@@ -142,7 +143,7 @@ function dbsingle {
 			echo
 			echo -e "${colred}Instance $my_sid is not running${colrst}. Cannot determine correct NLS_LANG."
 		else
-			L_props=`$ORACLE_HOME/bin/sqlplus -s / as sysdba <<EOF 2>/dev/null | grep -v -e '^$'
+			L_props=`$ORACLE_HOME/bin/sqlplus -s / as sysdba <<EOF 2>/dev/null | grep -v '^$'
 set echo off feedback off heading off
 SELECT 'export NLS_CHARSET='||value\\$ FROM sys.props\\$ WHERE name = 'NLS_CHARACTERSET' ;
 SELECT 'export DIAGNOSTIC_DEST='||value FROM v\\$parameter WHERE name = 'diagnostic_dest' ;
@@ -157,6 +158,7 @@ EOF
 	else
 		echo "Instance or DB $my_sid is not running on this server"
 	fi
+
 
 }
 
@@ -176,7 +178,8 @@ function dbrac {
 			if [ $my_sid == "MGMTDB" ] || [ $my_sid == "GIMR" ] ; then
 	                        export ORACLE_SID="-MGMTDB"
 				MGMTDB_HOST=`srvctl status mgmtdb | grep "is running" | awk '{print $NF}'`
-				CURRENT_HOST=`hostname -s`
+				CURRENT_HOST=`hostname`
+                                CURRENT_HOST=${CURRENT_HOST%%.*}
 				if [ "$MGMTDB_HOST" != $CURRENT_HOST ] ; then
 					echo "Warning: the MGMTDB is running on $MGMTDB_HOST, not here"
 				fi
@@ -204,7 +207,8 @@ function dbrac {
 			#	- a DB_UNIQUE_NAME (the local INSTANCE_NAME will be set automatically)
 			#	- a cluster resource name (the local INSTANCE_NAME will be set automatically)
 
-			l_short_hostname=`hostname -s`
+			l_short_hostname=`hostname`
+                        l_short_hostname=${l_short_hostname%%.*}
 			l_dbmatch=`crs_dblist | grep -i ":$my_sid:" | grep -i $l_short_hostname`
 			if [ $? -eq 0 ] ; then
 				export ORACLE_BASE=${ORACLE_BASE:-/u01/app/oracle}
@@ -234,7 +238,7 @@ function dbrac {
 					echo
 					echo -e "${colred}Instance $my_sid is ${CRS_DB_STATE}${colrst}. Cannot determine correct NLS_LANG."
 				else
-					L_props=`$ORACLE_HOME/bin/sqlplus -s / as sysdba <<EOF 2>/dev/null | grep -v -e '^$'
+					L_props=`$ORACLE_HOME/bin/sqlplus -s / as sysdba <<EOF 2>/dev/null | grep -v '^$'
 set echo off feedback off heading off
 SELECT 'export NLS_CHARSET='||value\\$ FROM sys.props\\$ WHERE name = 'NLS_CHARACTERSET' ;
 SELECT 'export DIAGNOSTIC_DEST='||value FROM v\\$parameter WHERE name = 'diagnostic_dest' ;
@@ -677,7 +681,7 @@ END{
 function racstat() {
 
 if [ $CRS_EXISTS -eq 1 ] ; then
-${CRSCTL} stat res -f -w "(TYPE = ora.database.type)" | awk -F= '
+${CRSCTL} stat res -f -w "(TYPE = ora.database.type)" | gawk -F= '
 
 function print_row() {
         dbbcol="";
@@ -815,6 +819,23 @@ else
 fi
 
 } # end of function cstat
+
+
+# Returns oratab file path (Solaris has different one)
+function oratab() {
+  for ota in /etc/oratab /var/opt/oracle/oratab; do
+   [[ -f "${ota}" ]] && echo "${ota}" && break
+  done
+}
+
+
+# Returns oraInst.loc file path (Solaris has different one)
+function orainst() {
+  for oil in /etc/oraInst.loc /var/opt/oracle/oraInst.loc; do
+   [[ -f "${oil}" ]] && echo "${oil}" && break
+  done
+}
+
 
 function ora_prompt() {
         PSERR=$?
@@ -1000,7 +1021,7 @@ END {
 
 
 function lsoh() {
-CENTRAL_ORAINV=`grep ^inventory_loc /etc/oraInst.loc 2>/dev/null | awk -F= '{print $2}'`
+CENTRAL_ORAINV=`grep ^inventory_loc $(orainst) 2>/dev/null | awk -F= '{print $2}'`
 IFS='
 '
 echo
@@ -1046,7 +1067,7 @@ function setoh() {
 
 SEARCH=${1:-"_foo_"}
 
-CENTRAL_ORAINV=`grep ^inventory_loc /etc/oraInst.loc 2>/dev/null | awk -F= '{print $2}'`
+CENTRAL_ORAINV=`grep ^inventory_loc $(orainst) 2>/dev/null | awk -F= '{print $2}'`
 IFS='
 '
 
@@ -1191,7 +1212,7 @@ ps -ef |grep [p]mon
 }
 
 function singlestat {
-    for db in `ps -eaf | grep [p]mon_ | awk -Fmon_ '{print $NF}'`;
+    for db in `ps -eaf | grep [p]mon_ | gawk -Fmon_ '{print $NF}' | gawk -F+ '{print $NF}'`;
     do
         declare "pmon$db=UP";
     done;
@@ -1199,12 +1220,15 @@ function singlestat {
     IFS="
 ";
     printf "%-13s %-8s %-50s\n" ORACLE_SID STATUS ORACLE_HOME;
-    l_hostname=`hostname -s`;
-    for dbline in `cat /etc/oratab | grep -v ^# | grep -v ^\$ `;
+    l_hostname=`hostname`;
+    ### substr to short name (hostname -s doesnt work on Solaris)
+    l_hostname=${l_hostname%%.*}
+    for dbline in `cat $(oratab) | grep -v ^# | grep -v ^\$ `;
     do
         sid=`echo $dbline | awk -F: '{print $1}'`;
         oh=`echo $dbline | awk -F: '{print $2}'`;
-        statvar=pmon$sid;
+        # Remove "+" from sid, if exists
+        statvar=pmon${sid#+};
         status=${!statvar:-DOWN};
         if [ "$status" == "UP" ]; then
             statcolor=${colgrn};
@@ -1217,6 +1241,6 @@ function singlestat {
 }
 
 function single_dblist () {
-    cat /etc/oratab | grep -v ^# | grep -v ^\$
+    cat $(oratab) | grep -v ^# | grep -v ^\$
 }
 

--- a/variables.conf
+++ b/variables.conf
@@ -23,15 +23,25 @@ export NLS_DATE_FORMAT="DD-MON-YYYY HH24:MI:SS"
 
 # The default path is always the same. When an environment is set, the specific PATH is prepended to this one.
 # This allows to have a clean PATH at every environment switch
-export DEFAULT_PATH=/usr/local/bin:/bin:/usr/bin:/usr/local/sbin:/usr/sbin:/sbin:${COE_BASE}/bin
+export DEFAULT_PATH=/usr/local/bin:/bin:/usr/bin:/usr/local/sbin:/usr/sbin:/sbin:${COE_BASE}/bin:/opt/csw/bin
 
-export CENTRAL_ORAINV=`grep ^inventory_loc /etc/oraInst.loc 2>/dev/null | awk -F= '{print $2}'`
+# Solaris / Lunix support
+for oil in /etc/oraInst.loc /var/opt/oracle/oraInst.loc; do
+  [[ -f "${oil}" ]] &&  orainstloc="${oil}" && break
+done
+
+for olr in /etc/oracle/olr.loc /var/opt/oracle/olr.loc; do
+  [[ -f "${olr}" ]] &&  olrloc="${olr}" && break
+done
+
+
+export CENTRAL_ORAINV=`grep ^inventory_loc ${orainstloc} 2>/dev/null | awk -F= '{print $2}'`
 export RLWRAP=$(which rlwrap)
 export EDITOR=$(which vi)
 
-if [ -f /etc/oracle/olr.loc ] ; then
+if [ -f /etc/oracle/olr.loc ] || [ -f /var/opt/oracle/olr.loc ]; then
 	# get the CRS HOME (using ORA_CLU_HOME as environment variable as ORA_CRS_HOME is reserved and might cause unexpected behaviour)
-	export ORA_CLU_HOME=`cat /etc/oracle/olr.loc 2>/dev/null | grep crs_home | awk -F= '{print $2}'`
+	export ORA_CLU_HOME=`cat ${olrloc} 2>/dev/null | grep crs_home | awk -F= '{print $2}'`
 
 	export CRS_EXISTS=1
 


### PR DESCRIPTION
Hi, Ludovico!
I'm very happy with your COE scripts. We have both Linux RHEL 7 and Oracle Solaris 11 environments, so i make some changes to the scripts.

I haven't tested all functions, but most useful   sid, db lsoh seems to be working on both RHEL 7 and Solaris 11. I hope i haven't broken anything else ;-)