### PR TITLE
Add export ORACLE_UNQNAME

### DIFF
--- a/functions.conf
+++ b/functions.conf
@@ -147,6 +147,7 @@ function dbsingle {
 set echo off feedback off heading off
 SELECT 'export NLS_CHARSET='||value\\$ FROM sys.props\\$ WHERE name = 'NLS_CHARACTERSET' ;
 SELECT 'export DIAGNOSTIC_DEST='||value FROM v\\$parameter WHERE name = 'diagnostic_dest' ;
+SELECT 'export ORACLE_UNQNAME='||value FROM v\\$parameter WHERE name = 'db_unique_name' ;
 EOF
 `
 			if [ -n "$L_props" ] ; then
@@ -243,6 +244,7 @@ function dbrac {
 set echo off feedback off heading off
 SELECT 'export NLS_CHARSET='||value\\$ FROM sys.props\\$ WHERE name = 'NLS_CHARACTERSET' ;
 SELECT 'export DIAGNOSTIC_DEST='||value FROM v\\$parameter WHERE name = 'diagnostic_dest' ;
+SELECT 'export ORACLE_UNQNAME='||value FROM v\\$parameter WHERE name = 'db_unique_name' ;
 EOF
 `
 					if [ -n "$L_props" ] ; then


### PR DESCRIPTION
For versions older than 19c, when multiple databases use the same `sqlnet.ora`, it is possible to define a different keystore location for each database using the variable $ORACLE_UNQNAME. Example :

```
# cat $ORACLE_HOME/network/admin/sqlnet.ora
ENCRYPTION_WALLET_LOCATION=
(SOURCE=(METHOD=FILE)
   (METHOD_DATA=(DIRECTORY=/u01/app/oracle/admin/$ORACLE_UNQNAME/wallet))
)
```

It is then necessary to define this variable in the environment. 